### PR TITLE
Updated checks to use the stores

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.0|^8.1",
         "illuminate/support": "^9.0|^10.0",
         "illuminate/view": "^9.0|^10.0",
-        "rapidez/core": "~0.91|^1.0"
+        "rapidez/core": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -1,11 +1,13 @@
 import 'Vendor/rapidez/core/resources/js/vue'
 import InteractWithUser from 'Vendor/rapidez/core/resources/js/components/User/mixins/InteractWithUser'
+import { mask } from 'Vendor/rapidez/core/resources/js/stores/useMask';
+import { token } from 'Vendor/rapidez/core/resources/js/stores/useUser'
 import GetCart from 'Vendor/rapidez/core/resources/js/components/Cart/mixins/GetCart'
 
 Vue.prototype.registerCallback = async function (variables, response) {
     await InteractWithUser.methods.login(variables.email, variables.password)
     await InteractWithUser.methods.refreshUser()
-    if (localStorage.cart && localStorage.mask) {
+    if (token.value && mask.value) {
         await GetCart.methods.linkUserToCart()
     }
 }


### PR DESCRIPTION
Because the cart was no longer being saved in localstorage and instead sessionstorage the check never became true.
Dropped support for rapidez 0.x but made the check storage engine independent