### PR TITLE
Make sortOrdersCallback compatible with Rapidez v2

### DIFF
--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -31,5 +31,5 @@ Vue.prototype.sortOrdersCallback = async function (data, response) {
         return new Date(b.order_date) - new Date(a.order_date)
     })
 
-    return response.data.data
+    return response.data
 }


### PR DESCRIPTION
In Rapidez v2, window.magentoGraphQL is used, so response.data.data should now be response.data