### PR TITLE
Fix the handling of the response with fetch

### DIFF
--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -13,7 +13,7 @@ Vue.prototype.refreshUserInfoCallback = async function (variables, response) {
 
 Vue.prototype.reorderCallback = async function (variables, response) {
     document.addEventListener('turbo:load', function showReorderErrors() {
-        response.data.data.reorderItems.userInputErrors.forEach((error) => {
+        response.data.reorderItems.userInputErrors.forEach((error) => {
             Notify(error.message, 'warning')
         })
         document.removeEventListener('turbo:load', showReorderErrors)


### PR DESCRIPTION
With the new fetch methods, the response is `response.data.reorderItems` instead of `response.data.data.reorderItems`. This causes the cart to not refresh on production and it "seems" like you haven't added the order items to the cart.