### PR TITLE
[3.x] Refresh user data on address change

### DIFF
--- a/resources/views/account/address-edit.blade.php
+++ b/resources/views/account/address-edit.blade.php
@@ -14,6 +14,7 @@
             <graphql-mutation
                 query="@include('rapidez::account.partials.queries.address-edit')"
                 :variables="Object.assign(data.customer.addresses.find(a => a.id == {{ request()->id }}), { id: {{ request()->id }} })"
+                :callback="refreshUserInfoCallback"
                 redirect="{{ route('account.addresses') }}"
             >
                 @include('rapidez::account.partials.address-form')

--- a/resources/views/account/address-new.blade.php
+++ b/resources/views/account/address-new.blade.php
@@ -5,7 +5,12 @@
 @section('robots', 'NOINDEX,NOFOLLOW')
 
 @section('account-content')
-    <graphql-mutation query="@include('rapidez::account.partials.queries.address-create')" :variables="{ street: [] }" redirect="{{ route('account.addresses') }}">
+    <graphql-mutation
+        query="@include('rapidez::account.partials.queries.address-create')"
+        :variables="{ street: [] }"
+        :callback="refreshUserInfoCallback"
+        redirect="{{ route('account.addresses') }}"
+    >
         @include('rapidez::account.partials.address-form')
     <graphql-mutation>
 @endsection

--- a/resources/views/account/addresses.blade.php
+++ b/resources/views/account/addresses.blade.php
@@ -50,7 +50,12 @@
                                     </a>
                                 </td>
                                 <td class="border px-4 py-2">
-                                    <graphql-mutation query="mutation deleteCustomerAddress($id: Int!){ deleteCustomerAddress ( id: $id ) }" :variables="{id: additionalAddress.id}" redirect="{{ route('account.addresses') }}">
+                                    <graphql-mutation
+                                        query="mutation deleteCustomerAddress($id: Int!){ deleteCustomerAddress ( id: $id ) }"
+                                        :variables="{ id: additionalAddress.id }"
+                                        :callback="refreshUserInfoCallback"
+                                        redirect="{{ route('account.addresses') }}"
+                                    >
                                         <div slot-scope="{ mutate }">
                                             <button v-on:click="mutate" class="underline hover:no-underline">
                                                 @lang('Delete')


### PR DESCRIPTION
When you edit, create, or delete an address, the user data didn't get updated. This meant that, for example, you couldn't select new addresses in the checkout.

The queries here only return a CustomerAddress object which doesn't really allow for a clean direct update of the user data. As such, I opted to just refresh all user data with an already existing callback. This means one extra query, which isn't great, but it's the cleanest option I could find

Note that this will also have to get fixed in the checkout theme (and the subsequent confira 3.x PR). I'll make a PR when there is a consensus on the solution for this problem :)