### PR TITLE
Fix country select

### DIFF
--- a/resources/views/account/partials/address-form.blade.php
+++ b/resources/views/account/partials/address-form.blade.php
@@ -104,7 +104,7 @@
         <div class="col-span-12 sm:col-span-4">
             <label>
                 <x-rapidez::label>@lang('Country')</x-rapidez::label>
-                <x-rapidez::country-select
+                <x-rapidez::input.select.country
                     name="country_code"
                     v-model="variables.country_code"
                     v-on:change="window.app.$emit('postcode-change', variables)"


### PR DESCRIPTION
In this [PR](https://github.com/rapidez/core/pull/678/files) the country-select is changed to **components/input/select/country.**. But it is never changed here so `<x-rapidez::country-select>` will break the form as it should be `<x-rapidez::input.select.country>` as we do here: https://github.com/rapidez/core/blob/master/resources/views/checkout/partials/address.blade.php#L151