### PR TITLE
Playwright less strict register testing

### DIFF
--- a/tests/playwright/pages/RegisterPage.js
+++ b/tests/playwright/pages/RegisterPage.js
@@ -18,6 +18,6 @@ export class RegisterPage {
         await this.page.getByTestId('continue').click()
         await this.page.waitForLoadState('networkidle')
         await this.page.waitForURL('/account')
-        await expect(this.page.getByTestId('account-content')).toContainText('Bruce');
+        await expect(this.page.getByTestId('account-content')).toBeVisible()
     }
 }


### PR DESCRIPTION
So the same test can be used within https://github.com/rapidez/checkout-theme/pull/196 where the name isn't displayed on the account overview page